### PR TITLE
fix: work with git‘s GIT_DIR

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,21 @@
 'use strict';
 
 const url = require('url');
+const path = require('path');
 const dotgitconfig = require('dotgitconfig');
 const { execSync } = require('child_process');
 
 module.exports = class LCL {
   constructor(dir = process.cwd()) {
+    this.gitDirStr = '';
     const { GIT_DIR } = process.env;
-    this.gitDirStr = GIT_DIR ? `--git-dir ${GIT_DIR}/.git` : '';
+    if (GIT_DIR) {
+      if (GIT_DIR.endsWith('/.git')) {
+        this.gitDirStr = `--git-dir=${GIT_DIR}`;
+      } else {
+        this.gitDirStr = `--git-dir=${path.resolve(GIT_DIR, './.git')}`;
+      }
+    }
     this.cwd = dir;
   }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 
 const LCL = require('..');
+const path = require('path');
 
 describe('./test/unit.test.js', () => {
   it('should parse git commands fully', () => {
@@ -60,6 +61,37 @@ describe('./test/unit.test.js', () => {
     }).catch(err => {
       // console.log(err.stack);
       assert(err.message.includes('Can\'t get last commit'));
+    });
+  });
+
+  // 应兼容git的GIT_DIR环境变量
+  // yhn@yhnMBP LCL % export GIT_DIR=/Users/yhn/github/LCL
+  // yhn@yhnMBP LCL % git pull
+  // fatal: not a git repository: '/Users/yhn/github/LCL'
+  // yhn@yhnMBP LCL % export GIT_DIR=/Users/yhn/github/LCL/.git
+  // yhn@yhnMBP LCL % git pull
+  // Already up to date.
+  it('should work with standard GIT_DIR', () => {
+    process.env.GIT_DIR = path.resolve(__dirname, '../.git');
+    console.log(process.env.GIT_DIR);
+    const lcl = new LCL();
+    return lcl.getLastCommit().then(commit => {
+      assert.ok(commit);
+      assert(commit.gitRemote === 'git@github.com:node-modules/last-commit-log.git' || commit.gitRemote === 'https://github.com/node-modules/last-commit-log.git');
+      assert(commit.gitUrl === 'http://github.com/node-modules/last-commit-log' || commit.gitUrl === 'https://github.com/node-modules/last-commit-log');
+      assert(typeof commit.shortHash === 'string');
+      assert(typeof commit.hash === 'string');
+      assert(typeof commit.subject === 'string');
+      assert(typeof commit.sanitizedSubject === 'string');
+      assert(typeof commit.body === 'string');
+      assert(typeof commit.committer.date === 'string');
+      assert(typeof commit.committer.relativeDate === 'string');
+      assert(typeof commit.committer.name === 'string');
+      assert(typeof commit.committer.email === 'string');
+      assert(typeof commit.author.date === 'string');
+      assert(typeof commit.author.relativeDate === 'string');
+      assert(typeof commit.author.name === 'string');
+      assert(typeof commit.author.email === 'string');
     });
   });
 });


### PR DESCRIPTION
when you use GIT_DIR, it will cause problems with git
solve problems like this

yhn@yhnMBP LCL % export GIT_DIR=/Users/yhn/github/LCL
yhn@yhnMBP LCL % git pull
fatal: not a git repository: '/Users/yhn/github/LCL'
yhn@yhnMBP LCL % export GIT_DIR=/Users/yhn/github/LCL/.git
yhn@yhnMBP LCL % git pull
Already up to date.
