### PR TITLE
fix: add `stdio: 'pipe'` option to execSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ module.exports = class LCL {
       const opts = {
         cwd: this.cwd,
         maxBuffer: 1024 * 1024 * 1024,
+        // <https://stackoverflow.com/a/45578119
+        // <https://github.com/cabinjs/axe/issues/15>
+        stdio: 'pipe',
       };
       const stdout = execSync(command, opts).toString();
       c = stdout.split(splitCharacter);


### PR DESCRIPTION
This fixes https://github.com/cabinjs/axe/issues/15.  See <https://stackoverflow.com/a/45578119> for more insight.