### PR TITLE
fix: use windowsHide for git child processes on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,12 @@ const path = require('path');
 const dotgitconfig = require('dotgitconfig');
 const { execSync } = require('child_process');
 
+/**
+ * Prevents obnoxious cmd window popping up on Windows when process runs via pm2
+ * instead of via an already visible terminal.
+ */
+const baseExecOptions = { windowsHide: true };
+
 module.exports = class LCL {
   constructor(dir = process.cwd()) {
     this.gitDirStr = '';
@@ -38,6 +44,7 @@ module.exports = class LCL {
     let gitTag;
     try {
       const opts = {
+        ...baseExecOptions,
         cwd: this.cwd,
         maxBuffer: 1024 * 1024 * 1024,
         // <https://stackoverflow.com/a/45578119
@@ -112,7 +119,7 @@ module.exports = class LCL {
   }
 
   getUserNameSync() {
-    return execSync(`git ${this.gitDirStr} config user.name`)
+    return execSync(`git ${this.gitDirStr} config user.name`, baseExecOptions)
       .toString()
       .trim();
   }

--- a/line-diff.js
+++ b/line-diff.js
@@ -2,6 +2,12 @@
 
 const { execSync } = require('child_process');
 
+/**
+ * Avoid cmd popups on Windows when there is no visible console (e.g. pm2).
+ * @see index.js baseExecOptions
+ */
+const execOptions = { windowsHide: true };
+
 const fileNameReg = /diff --git a(.*) b.*/;
 const lineReg = /@@ -(.*) \+(.*) @@/;
 
@@ -25,7 +31,7 @@ module.exports = (options = {}) => {
     currentBranch,
     filter,
   ].join(' ');
-  const str = execSync(cmd).toString().trim();
+  const str = execSync(cmd, execOptions).toString().trim();
   if (!str) return null;
   const diffMap = {};
   const diffArray = str.split('\n');


### PR DESCRIPTION
## Problem I am facing

When `last-commit-log` runs under pm2 on Windows, there is no visible console. Each `execSync` can spawn a flashing cmd window, which interferes with typing and is annoying!

## Solution

Set `windowsHide: true` on all `child_process.execSync` options (shared via `baseExecOptions`).

## Issue

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Windows user experience by preventing console windows from appearing during background operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->